### PR TITLE
Allow whitespace lines in cells.

### DIFF
--- a/hy_kernel/hy_kernel.py
+++ b/hy_kernel/hy_kernel.py
@@ -90,7 +90,7 @@ class HyKernel(IPythonKernel):
                     if line[:2] == "%%":
                         # cell magic
                         cell.append(line)
-                    elif line[:1] in "!%":
+                    elif len(line) > 0 and line[0] in "!%":
                         # line magic
                         if chunk:
                             cell.append(self.compile_chunk(chunk))

--- a/hy_kernel/hy_kernel.py
+++ b/hy_kernel/hy_kernel.py
@@ -90,7 +90,7 @@ class HyKernel(IPythonKernel):
                     if line[:2] == "%%":
                         # cell magic
                         cell.append(line)
-                    elif line[0] in "!%":
+                    elif line[:1] in "!%":
                         # line magic
                         if chunk:
                             cell.append(self.compile_chunk(chunk))


### PR DESCRIPTION
Addresses #22.

The crash was due to a check for `line[0] in "!%"`. Checking that the line has something in it fixes the issue.

Whitespace lines are not included in the stack trace for errors. For obvious reasons, I have no way to see if this is a regression. Based on the fact that comment lines do not show up in said stack trace with or without my patch, my guess is that it is not.